### PR TITLE
Use lookupParam() for parameter queries in kinematics plugins

### DIFF
--- a/include/bio_ik/goal.h
+++ b/include/bio_ik/goal.h
@@ -41,8 +41,6 @@
 #include <moveit/robot_model/joint_model_group.h>
 #include <moveit/robot_model/robot_model.h>
 
-#include <ros/node_handle.h>
-
 namespace bio_ik
 {
 
@@ -59,7 +57,6 @@ protected:
     std::vector<std::string> goal_link_names_, goal_variable_names_;
     double goal_weight_;
     const moveit::core::JointModelGroup* joint_model_group_;
-    ros::NodeHandle node_handle_;
     std::vector<size_t> problem_active_variables_;
     std::vector<size_t> problem_tip_link_indices_;
     std::vector<double> initial_guess_;
@@ -93,7 +90,6 @@ public:
     void setWeight(double weight) { goal_weight_ = weight; }
     const moveit::core::JointModelGroup& getJointModelGroup() const { return *joint_model_group_; }
     const moveit::core::RobotModel& getRobotModel() const { return joint_model_group_->getParentModel(); }
-    const ros::NodeHandle& getNodeHandle() const { return node_handle_; }
     std::vector<double>& getTempVector() const { return temp_vector_; }
     friend class Problem;
 };

--- a/src/ik_base.h
+++ b/src/ik_base.h
@@ -46,13 +46,6 @@
 namespace bio_ik
 {
 
-struct IKParams
-{
-    moveit::core::RobotModelConstPtr robot_model;
-    const moveit::core::JointModelGroup* joint_model_group;
-    ros::NodeHandle node_handle;
-};
-
 struct Random
 {
     // std::mt19937 rng;

--- a/src/ik_evolution_1.cpp
+++ b/src/ik_evolution_1.cpp
@@ -132,11 +132,10 @@ struct IKEvolution1 : IKBase
 
     void setParams(const IKParams& p)
     {
-        auto& n = p.node_handle;
-        n.param("no_wipeout", opt_no_wipeout, false);
-        n.param("population_size", populationSize, 8);
-        n.param("elite_count", eliteCount, 4);
-        n.param("linear_fitness", linear_fitness, false);
+        opt_no_wipeout = p.opt_no_wipeout;
+        populationSize = p.population_size;
+        eliteCount = p.elite_count;
+        linear_fitness = p.linear_fitness;
     }
 
     bool in_final_adjustment_loop;

--- a/src/ik_parallel.h
+++ b/src/ik_parallel.h
@@ -111,20 +111,16 @@ struct IKParallel
         : params(params)
     {
         // solver class name
-        std::string name;
-        // params.node_handle.param("mode", name, std::string("bio1"));
-        // params.node_handle.param("mode", name, std::string("bio2_memetic_l"));
-        // params.node_handle.param("mode", name, std::string("bio2"));
-        params.node_handle.param("mode", name, std::string("bio2_memetic"));
-        // params.node_handle.param("mode", name, std::string("bio3_memetic"));
-        // params.node_handle.param("mode", name, std::string("neural"));
+        std::string name = params.solver_class_name;
 
-        params.node_handle.param("counter", enable_counter, false);
+        enable_counter = params.enable_counter;
 
         // create solvers
         solvers.emplace_back(IKFactory::create(name, params));
         thread_count = solvers.front()->concurrency();
-        params.node_handle.param("threads", thread_count, thread_count);
+        if(params.thread_count) {
+            thread_count = params.thread_count;
+        }
         while(solvers.size() < thread_count)
             solvers.emplace_back(IKFactory::clone(solvers.front().get()));
         for(size_t i = 0; i < thread_count; i++)

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -199,7 +199,6 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
         robot_info = RobotInfo(robot_model);
 
         ikparams.robot_model = robot_model;
-        ikparams.node_handle = node_handle;
         ikparams.joint_model_group = joint_model_group;
 
         // initialize parameters for IKParallel

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -207,6 +207,13 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
         lookupParam("drot", ikparams.drot, DBL_MAX);
         lookupParam("dtwist", ikparams.dtwist, 1e-5);
 
+        // initialize parameters for ik_evolution_1
+        lookupParam("no_wipeout", ikparams.opt_no_wipeout, false);
+        lookupParam("population_size", ikparams.population_size, 8);
+        lookupParam("elite_count", ikparams.elite_count, 4);
+        lookupParam("linear_fitness", ikparams.linear_fitness, false);
+
+
         temp_state.reset(new moveit::core::RobotState(robot_model));
 
         ik.reset(new IKParallel(ikparams));

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -187,11 +187,6 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
         // for(auto& n : joint_names) LOG("joint", n);
         // for(auto& n : link_names) LOG("link", n);
 
-        ros::NodeHandle node_handle("~");
-        std::string rdesc;
-        node_handle.searchParam(robot_description_, rdesc);
-        node_handle = ros::NodeHandle(rdesc + "_kinematics/" + group_name_);
-
         // bool enable_profiler;
         lookupParam("profiler", enable_profiler, false);
         // if(enable_profiler) Profiler::start();

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -193,7 +193,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
         node_handle = ros::NodeHandle(rdesc + "_kinematics/" + group_name_);
 
         // bool enable_profiler;
-        node_handle.param("profiler", enable_profiler, false);
+        lookupParam("profiler", enable_profiler, false);
         // if(enable_profiler) Profiler::start();
 
         robot_info = RobotInfo(robot_model);
@@ -238,10 +238,10 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
 
                 double rotation_scale = 0.5;
 
-                node_handle.param("rotation_scale", rotation_scale, rotation_scale);
+                lookupParam("rotation_scale", rotation_scale, rotation_scale);
 
                 bool position_only_ik = false;
-                node_handle.param("position_only_ik", position_only_ik, position_only_ik);
+                lookupParam("position_only_ik", position_only_ik, position_only_ik);
                 if(position_only_ik) rotation_scale = 0;
 
                 goal->setRotationScale(rotation_scale);
@@ -251,7 +251,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
 
             {
                 double weight = 0;
-                node_handle.param("center_joints_weight", weight, weight);
+                lookupParam("center_joints_weight", weight, weight);
                 if(weight > 0.0)
                 {
                     auto* avoid_joint_limits_goal = new bio_ik::CenterJointsGoal();
@@ -262,7 +262,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
 
             {
                 double weight = 0;
-                node_handle.param("avoid_joint_limits_weight", weight, weight);
+                lookupParam("avoid_joint_limits_weight", weight, weight);
                 if(weight > 0.0)
                 {
                     auto* avoid_joint_limits_goal = new bio_ik::AvoidJointLimitsGoal();
@@ -273,7 +273,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
 
             {
                 double weight = 0;
-                node_handle.param("minimal_displacement_weight", weight, weight);
+                lookupParam("minimal_displacement_weight", weight, weight);
                 if(weight > 0.0)
                 {
                     auto* minimal_displacement_goal = new bio_ik::MinimalDisplacementGoal();

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -202,6 +202,11 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
         ikparams.node_handle = node_handle;
         ikparams.joint_model_group = joint_model_group;
 
+        // initialize parameters for Problem
+        lookupParam("dpos", ikparams.dpos, DBL_MAX);
+        lookupParam("drot", ikparams.drot, DBL_MAX);
+        lookupParam("dtwist", ikparams.dtwist, 1e-5);
+
         temp_state.reset(new moveit::core::RobotState(robot_model));
 
         ik.reset(new IKParallel(ikparams));
@@ -438,7 +443,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
 
             {
                 BLOCKPROFILER("problem init");
-                problem.initialize(ikparams.robot_model, ikparams.joint_model_group, ikparams.node_handle, all_goals, bio_ik_options);
+                problem.initialize(ikparams.robot_model, ikparams.joint_model_group, ikparams, all_goals, bio_ik_options);
                 // problem.setGoals(default_goals, ikparams);
             }
         }

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -202,6 +202,11 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase
         ikparams.node_handle = node_handle;
         ikparams.joint_model_group = joint_model_group;
 
+        // initialize parameters for IKParallel
+        lookupParam("mode", ikparams.solver_class_name, std::string("bio2_memetic"));
+        lookupParam("counter", ikparams.enable_counter, false);
+        lookupParam("threads", ikparams.thread_count, 0);
+
         // initialize parameters for Problem
         lookupParam("dpos", ikparams.dpos, DBL_MAX);
         lookupParam("drot", ikparams.drot, DBL_MAX);

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -69,7 +69,7 @@ Problem::Problem()
 {
 }
 
-void Problem::initialize(moveit::core::RobotModelConstPtr robot_model, const moveit::core::JointModelGroup* joint_model_group, ros::NodeHandle node_handle, const std::vector<const Goal*>& goals2, const BioIKKinematicsQueryOptions* options)
+void Problem::initialize(moveit::core::RobotModelConstPtr robot_model, const moveit::core::JointModelGroup* joint_model_group, const IKParams& params, const std::vector<const Goal*>& goals2, const BioIKKinematicsQueryOptions* options)
 {
     if(robot_model != this->robot_model)
     {
@@ -80,15 +80,14 @@ void Problem::initialize(moveit::core::RobotModelConstPtr robot_model, const mov
 
     this->robot_model = robot_model;
     this->joint_model_group = joint_model_group;
-    this->node_handle = node_handle;
+    this->params = params;
 
     if(!ros_params_initrd)
     {
         ros_params_initrd = true;
-        auto& n = node_handle;
-        n.param("dpos", dpos, DBL_MAX);
-        n.param("drot", drot, DBL_MAX);
-        n.param("dtwist", dtwist, 1e-5);
+        dpos = params.dpos;
+        drot = params.drot;
+        dtwist = params.dtwist;
         if(dpos < 0.0 || dpos >= FLT_MAX || !std::isfinite(dpos)) dpos = DBL_MAX;
         if(drot < 0.0 || drot >= FLT_MAX || !std::isfinite(drot)) drot = DBL_MAX;
         if(dtwist < 0.0 || dtwist >= FLT_MAX || !std::isfinite(dtwist)) dtwist = DBL_MAX;

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -232,7 +232,6 @@ void Problem::initialize2()
     {
         for(auto& g : *gg)
         {
-            g.goal_context.node_handle_ = node_handle;
             g.goal_context.problem_active_variables_ = active_variables;
             g.goal_context.problem_tip_link_indices_ = tip_link_indices;
             g.goal_context.velocity_weights_ = minimal_displacement_factors;

--- a/src/problem.h
+++ b/src/problem.h
@@ -59,7 +59,7 @@ private:
     std::vector<double> joint_transmission_goal_temp, joint_transmission_goal_temp2;
     moveit::core::RobotModelConstPtr robot_model;
     const moveit::core::JointModelGroup* joint_model_group;
-    ros::NodeHandle node_handle;
+    IKParams params;
     RobotInfo modelInfo;
     double dpos, drot, dtwist;
     struct CollisionShape
@@ -133,7 +133,7 @@ public:
     std::vector<GoalInfo> goals;
     std::vector<GoalInfo> secondary_goals;
     Problem();
-    void initialize(moveit::core::RobotModelConstPtr robot_model, const moveit::core::JointModelGroup* joint_model_group, ros::NodeHandle node_handle, const std::vector<const Goal*>& goals2, const BioIKKinematicsQueryOptions* options);
+    void initialize(moveit::core::RobotModelConstPtr robot_model, const moveit::core::JointModelGroup* joint_model_group, const IKParams& params, const std::vector<const Goal*>& goals2, const BioIKKinematicsQueryOptions* options);
     void initialize2();
     double computeGoalFitness(GoalInfo& goal, const Frame* tip_frames, const double* active_variable_positions);
     double computeGoalFitness(std::vector<GoalInfo>& goals, const Frame* tip_frames, const double* active_variable_positions);

--- a/src/utils.h
+++ b/src/utils.h
@@ -65,7 +65,6 @@ struct IKParams
 {
     moveit::core::RobotModelConstPtr robot_model;
     const moveit::core::JointModelGroup* joint_model_group;
-    ros::NodeHandle node_handle;
 
     // IKParallel parameters
     std::string solver_class_name;

--- a/src/utils.h
+++ b/src/utils.h
@@ -66,6 +66,12 @@ struct IKParams
     moveit::core::RobotModelConstPtr robot_model;
     const moveit::core::JointModelGroup* joint_model_group;
     ros::NodeHandle node_handle;
+
+    //Problem parameters
+    double dpos;
+    double drot;
+    double dtwist;
+
 };
 
 #define ENABLE_LOG

--- a/src/utils.h
+++ b/src/utils.h
@@ -61,6 +61,13 @@
 namespace bio_ik
 {
 
+struct IKParams
+{
+    moveit::core::RobotModelConstPtr robot_model;
+    const moveit::core::JointModelGroup* joint_model_group;
+    ros::NodeHandle node_handle;
+};
+
 #define ENABLE_LOG
 
 #define ENABLE_PROFILER

--- a/src/utils.h
+++ b/src/utils.h
@@ -72,6 +72,11 @@ struct IKParams
     double drot;
     double dtwist;
 
+    // ik_evolution_1 parameters
+    bool opt_no_wipeout;
+    int population_size;
+    int elite_count;
+    bool linear_fitness;
 };
 
 #define ENABLE_LOG

--- a/src/utils.h
+++ b/src/utils.h
@@ -67,6 +67,11 @@ struct IKParams
     const moveit::core::JointModelGroup* joint_model_group;
     ros::NodeHandle node_handle;
 
+    // IKParallel parameters
+    std::string solver_class_name;
+    bool enable_counter;
+    int thread_count;
+
     //Problem parameters
     double dpos;
     double drot;


### PR DESCRIPTION
The function lookupParam() offers enhanced parameter query for moveit kinematics plugins as proposed [here](https://github.com/ros-planning/moveit/pull/701) and [here](https://github.com/ros-planning/moveit/pull/714).
Parameters can now be set inside the kinematics.yaml and even for the corresponding group.

This implementation also declares all required parameters inside IKParams so that the node handle is not passed down the hierarchy. In fact all direct node handle references are removed from the plugin.