### PR TITLE
Eigen::Affine -> Eigen::Isometry

### DIFF
--- a/include/bio_ik/frame.h
+++ b/include/bio_ik/frame.h
@@ -68,7 +68,7 @@ struct Frame
         tf::quaternionMsgToTF(msg.orientation, rot);
         pos = tf::Vector3(msg.position.x, msg.position.y, msg.position.z);
     }
-    explicit inline Frame(const Eigen::Affine3d& f)
+    explicit inline Frame(const Eigen::Isometry3d& f)
     {
         pos = tf::Vector3(f.translation().x(), f.translation().y(), f.translation().z());
         Eigen::Quaterniond q(f.rotation());

--- a/src/forward_kinematics.h
+++ b/src/forward_kinematics.h
@@ -128,7 +128,7 @@ public:
         default:
         {
             auto* joint_variables = variables + joint_model->getFirstVariableIndex();
-            Eigen::Affine3d joint_transform;
+            Eigen::Isometry3d joint_transform;
             joint_model->computeTransform(joint_variables, joint_transform);
             frame = Frame(joint_transform);
             break;

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -153,7 +153,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
     return false;
   }
 
-  std::vector<Eigen::Affine3d> tip_reference_frames;
+  EigenSTL::vector_Isometry3d tip_reference_frames;
 
   mutable std::vector<std::unique_ptr<Goal>> default_goals;
 
@@ -466,7 +466,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
       // transform tips to baseframe
       tipFrames.clear();
       for (size_t i = 0; i < ik_poses.size(); i++) {
-        Eigen::Affine3d p, r;
+        Eigen::Isometry3d p, r;
         tf::poseMsgToEigen(ik_poses[i], p);
         if (context_state) {
           r = context_state->getGlobalLinkTransform(getBaseFrame());


### PR DESCRIPTION
Switch Eigen transform type to `Eigen::Isometry`, which is more efficient than `Eigen::Affine` when it comes to inversion. Because Eigen::Isometry easily converts to Eigen::Affine (but not vice versa), MoveIt Melodic requires this change.