### PR TITLE
Disable logging and profiling

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -83,9 +83,11 @@ struct IKParams
     bool linear_fitness;
 };
 
-#define ENABLE_LOG
+// Uncomment to enable logging
+//#define ENABLE_LOG
 
-#define ENABLE_PROFILER
+// Uncomment to enable profiling
+//#define ENABLE_PROFILER
 
 // logging
 


### PR DESCRIPTION
This pull request disables logging and profiling because they are both not needed in a production environment. It closes #19.