### PR TITLE
Update to ConvexMesh pimpl API

### DIFF
--- a/include/bio_ik/goal_types.h
+++ b/include/bio_ik/goal_types.h
@@ -41,8 +41,8 @@
 #include <tf2/LinearMath/Vector3.h>
 #include <tf2/LinearMath/Quaternion.h>
 
-#include <moveit/collision_detection/collision_robot.h>
-#include <moveit/collision_detection_fcl/collision_robot_fcl.h>
+#include <moveit/collision_detection/collision_common.h>
+#include <moveit/collision_detection_fcl/collision_common.h>
 
 #include <map>
 #include <unordered_set>

--- a/src/goal_types.cpp
+++ b/src/goal_types.cpp
@@ -97,7 +97,7 @@ void TouchGoal::describe(GoalContext& context) const
                             polygons.push_back(triangles[triangle_index * 3 + 1]);
                             polygons.push_back(triangles[triangle_index * 3 + 2]);
                         }
-                        // By default, planes are in the correct order
+                        // planes are given in the same order as the triangles, though redundant ones will appear only once.
                         for(const auto& plane : getPlanes())
                         {
                             // planes stored as Eigen::Vector4d(nx, ny, nz, d)

--- a/src/goal_types.cpp
+++ b/src/goal_types.cpp
@@ -80,25 +80,27 @@ void TouchGoal::describe(GoalContext& context) const
                     void init(const shapes::Shape* shape)
                     {
                         type_ = shapes::MESH;
-                        scaled_vertices_ = 0;
+                        scaled_vertices_ = nullptr;
                         {
                             static std::mutex mutex;
                             std::lock_guard<std::mutex> lock(mutex);
                             setDimensions(shape);
                         }
-                        for(auto& v : mesh_data_->vertices_)
+                        for(const auto& v : getVertices())
                             points.emplace_back(v.x(), v.y(), v.z());
-                        for(size_t triangle_index = 0; triangle_index < mesh_data_->triangles_.size() / 3; triangle_index++)
+
+                        const auto& triangles = getTriangles();
+                        for(size_t triangle_index = 0; triangle_index < triangles.size() / 3; triangle_index++)
                         {
                             polygons.push_back(3);
-                            polygons.push_back(mesh_data_->triangles_[triangle_index * 3 + 0]);
-                            polygons.push_back(mesh_data_->triangles_[triangle_index * 3 + 1]);
-                            polygons.push_back(mesh_data_->triangles_[triangle_index * 3 + 2]);
+                            polygons.push_back(triangles[triangle_index * 3 + 0]);
+                            polygons.push_back(triangles[triangle_index * 3 + 1]);
+                            polygons.push_back(triangles[triangle_index * 3 + 2]);
                         }
-                        for(size_t triangle_index = 0; triangle_index < mesh_data_->triangles_.size() / 3; triangle_index++)
+                        // By default, planes are in the correct order
+                        for(const auto& plane : getPlanes())
                         {
-                            auto plane_index = mesh_data_->plane_for_triangle_[triangle_index];
-                            auto plane = mesh_data_->planes_[plane_index];
+                            // planes stored as Eigen::Vector4d(nx, ny, nz, d)
                             plane_normals.emplace_back(plane.x(), plane.y(), plane.z());
                             plane_dis.push_back(plane.w());
                         }

--- a/src/problem.h
+++ b/src/problem.h
@@ -41,8 +41,8 @@
 
 #include <geometric_shapes/shapes.h>
 
-#include <moveit/collision_detection/collision_robot.h>
-#include <moveit/collision_detection_fcl/collision_robot_fcl.h>
+#include <moveit/collision_detection/collision_common.h>
+#include <moveit/collision_detection_fcl/collision_common.h>
 
 #include <bio_ik/goal.h>
 


### PR DESCRIPTION
This applies fixes for supporting the latest `noetic-devel` branch of `geometric_shapes`. The `MeshData` is now  a pimpl structure https://github.com/ros-planning/geometric_shapes/commit/3f9eed45d5f1a110d3f089b383f12ba2f675dc1d so I switched it to using the getter functions.

@philipp1234 @v4hn 