### PR TITLE
fix dependency on private mesh_data

### DIFF
--- a/src/goal_types.cpp
+++ b/src/goal_types.cpp
@@ -86,19 +86,20 @@ void TouchGoal::describe(GoalContext& context) const
                             std::lock_guard<std::mutex> lock(mutex);
                             setDimensions(shape);
                         }
-                        for(auto& v : mesh_data_->vertices_)
+                        for(auto& v : getVertices())
                             points.emplace_back(v.x(), v.y(), v.z());
-                        for(size_t triangle_index = 0; triangle_index < mesh_data_->triangles_.size() / 3; triangle_index++)
+                        const auto &triangles = getTriangles();
+                        for(size_t triangle_index = 0; triangle_index < triangles.size() / 3; triangle_index++)
                         {
                             polygons.push_back(3);
-                            polygons.push_back(mesh_data_->triangles_[triangle_index * 3 + 0]);
-                            polygons.push_back(mesh_data_->triangles_[triangle_index * 3 + 1]);
-                            polygons.push_back(mesh_data_->triangles_[triangle_index * 3 + 2]);
+                            polygons.push_back(triangles[triangle_index * 3 + 0]);
+                            polygons.push_back(triangles[triangle_index * 3 + 1]);
+                            polygons.push_back(triangles[triangle_index * 3 + 2]);
                         }
-                        for(size_t triangle_index = 0; triangle_index < mesh_data_->triangles_.size() / 3; triangle_index++)
+                        const auto &planes = getPlanes();
+                        for(size_t triangle_index = 0; triangle_index < triangles.size() / 3; triangle_index++)
                         {
-                            auto plane_index = mesh_data_->plane_for_triangle_[triangle_index];
-                            auto plane = mesh_data_->planes_[plane_index];
+                            auto plane = planes[triangle_index];
                             plane_normals.emplace_back(plane.x(), plane.y(), plane.z());
                             plane_dis.push_back(plane.w());
                         }


### PR DESCRIPTION
This patch fixes build with ROS noetic. In the ROS noetic release of MoveIt, mesh_data is private.

Please check if the `plane_for_triangle` replacement is correct.