### PR TITLE
Don't wrap continuous joint angles

### DIFF
--- a/include/bio_ik/robot_info.h
+++ b/include/bio_ik/robot_info.h
@@ -56,7 +56,7 @@ class RobotInfo
     std::vector<VariableInfo> variables;
     std::vector<size_t> activeVariables;
     std::vector<moveit::core::JointModel::JointType> variable_joint_types;
-    std::vector<bool> continuous_joints;
+    std::vector<bool> has_bounds;
     moveit::core::RobotModelConstPtr robot_model;
 
     __attribute__((always_inline)) static inline double clamp2(double v, double lo, double hi)
@@ -98,7 +98,7 @@ public:
             info.max_velocity_rcp = info.max_velocity > 0.0 ? 1.0 / info.max_velocity : 0.0;
 
             variables.push_back(info);
-            continuous_joints.push_back(!bounded);
+            has_bounds.push_back(!bounded);
         }
 
         for(size_t ivar = 0; ivar < model->getVariableCount(); ivar++)
@@ -122,7 +122,7 @@ public:
 
     inline bool isRevolute(size_t variable_index) const { return variable_joint_types[variable_index] == moveit::core::JointModel::REVOLUTE; }
     inline bool isPrismatic(size_t variable_index) const { return variable_joint_types[variable_index] == moveit::core::JointModel::PRISMATIC; }
-    inline bool isContinuous(size_t variable_index) const { return continuous_joints[variable_index]; }
+    inline bool hasBounds(size_t variable_index) const { return has_bounds[variable_index]; }
     inline double getMaxVelocity(size_t i) const { return variables[i].max_velocity; }
     inline double getMaxVelocityRcp(size_t i) const { return variables[i].max_velocity_rcp; }
 };

--- a/include/bio_ik/robot_info.h
+++ b/include/bio_ik/robot_info.h
@@ -98,7 +98,7 @@ public:
             info.max_velocity_rcp = info.max_velocity > 0.0 ? 1.0 / info.max_velocity : 0.0;
 
             variables.push_back(info);
-            has_bounds.push_back(!bounded);
+            has_bounds.push_back(bounded);
         }
 
         for(size_t ivar = 0; ivar < model->getVariableCount(); ivar++)

--- a/include/bio_ik/robot_info.h
+++ b/include/bio_ik/robot_info.h
@@ -56,6 +56,7 @@ class RobotInfo
     std::vector<VariableInfo> variables;
     std::vector<size_t> activeVariables;
     std::vector<moveit::core::JointModel::JointType> variable_joint_types;
+    std::vector<bool> continuous_joints;
     moveit::core::RobotModelConstPtr robot_model;
 
     __attribute__((always_inline)) static inline double clamp2(double v, double lo, double hi)
@@ -97,6 +98,7 @@ public:
             info.max_velocity_rcp = info.max_velocity > 0.0 ? 1.0 / info.max_velocity : 0.0;
 
             variables.push_back(info);
+            continuous_joints.push_back(!bounded);
         }
 
         for(size_t ivar = 0; ivar < model->getVariableCount(); ivar++)
@@ -120,6 +122,7 @@ public:
 
     inline bool isRevolute(size_t variable_index) const { return variable_joint_types[variable_index] == moveit::core::JointModel::REVOLUTE; }
     inline bool isPrismatic(size_t variable_index) const { return variable_joint_types[variable_index] == moveit::core::JointModel::PRISMATIC; }
+    inline bool isContinuous(size_t variable_index) const { return continuous_joints[variable_index]; }
     inline double getMaxVelocity(size_t i) const { return variables[i].max_velocity; }
     inline double getMaxVelocityRcp(size_t i) const { return variables[i].max_velocity_rcp; }
 };

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -611,8 +611,8 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
       }
       state[ivar] = v;
 
-      // wrap angles that are not continuous
-      if(!robot_info.hasBounds(ivar))
+      // wrap angles that are bounded
+      if(robot_info.hasBounds(ivar))
       {
         auto* joint_model = robot_model->getJointOfVariable(ivar);
         joint_model->enforcePositionBounds(state.data() + ivar, joint_model->getVariableBounds());

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -612,7 +612,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
       state[ivar] = v;
 
       // wrap angles that are not continuous
-      if(!robot_info.isContinuous(ivar))
+      if(!robot_info.hasBounds(ivar))
       {
         auto* joint_model = robot_model->getJointOfVariable(ivar);
         joint_model->enforcePositionBounds(state.data() + ivar, joint_model->getVariableBounds());


### PR DESCRIPTION
Hi!

I was working on a project involving incremental tracking and I noticed that a continuous-revolute joint on the robot would suddenly flip almost 360 degrees (thankfully was doing this in sim) to get to an angle just a tad bit CW or CCW of the current position. Thanks to a pointer from [Andy Zelenak](https://github.com/AndyZe), it looked like the [angle-wrapping code](https://github.com/TAMS-Group/bio_ik/blob/master/src/kinematics_plugin.cpp#L579) would wrap around even continuous joint angles leading to these jumpy motions that I was seeing. This PR creates a fix for it that I've verified to be working on my project.