### PR TITLE
Support passing random seed as a parameter

### DIFF
--- a/src/ik_base.h
+++ b/src/ik_base.h
@@ -115,8 +115,8 @@ struct Random
         return random_gauss_buffer + i;
     }
 
-    Random()
-        : rng(std::random_device()())
+    Random(std::minstd_rand::result_type seed)
+        : rng(seed)
     {
         random_buffer = make_random_buffer();
         random_buffer_index = _xorshift();
@@ -142,7 +142,8 @@ struct IKBase : Random
     virtual void setParams(const IKParams& p) {}
 
     IKBase(const IKParams& p)
-        : model(p.robot_model)
+        : Random(p.random_seed)
+        , model(p.robot_model)
         , modelInfo(p.robot_model)
         , params(p)
     {

--- a/src/kinematics_plugin.cpp
+++ b/src/kinematics_plugin.cpp
@@ -253,6 +253,7 @@ struct BioIKKinematicsPlugin : kinematics::KinematicsBase {
                 std::string("bio2_memetic"));
     lookupParam("counter", ikparams.enable_counter, false);
     lookupParam("threads", ikparams.thread_count, 0);
+    lookupParam("random_seed", ikparams.random_seed, static_cast<int>(std::random_device()()));
 
     // initialize parameters for Problem
     lookupParam("dpos", ikparams.dpos, DBL_MAX);

--- a/src/utils.h
+++ b/src/utils.h
@@ -70,6 +70,7 @@ struct IKParams
     std::string solver_class_name;
     bool enable_counter;
     int thread_count;
+    int random_seed;
 
     //Problem parameters
     double dpos;


### PR DESCRIPTION
bio_ik uses std::random_device() to initialize the random number
generator by default, resulting in flaky unit tests if a seed fails to
converge. This patch adds a random_seed parameter to IKParams to
externally seed bio_ik and make it deterministic.

Note that this is a ABI break.